### PR TITLE
Enhance configuration and handle partial selections.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
+			"console": "integratedTerminal",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,52 @@
 
 A VS Code wrapper for [clj-zprint](https://github.com/kkinnear/zprint) written in `cljs`, built with [Shadow CLJS](http://shadow-cljs.org/).
 
+
 ## Configuration
 
-First, we look for a `.zprintrc` file in the current workspace and uses that for configuration.  If not found, then we look in the user's home directory.  Finally, `zprint` defaults will be used if no configuration file is found.  Granular, in-editor configuration to be considered for future versions.
+Configuration follows `zprint` as closely as possible.  First, we look
+for a `.zprintrc` or `.zprint.edn` in the user's home directory.
+Either will be used, if found.  If neither are found, configuration
+is complete.  If either are found, configuration continues.
+
+If `:search-config?` is true then we will look in the current
+workspace for either a `.zprintrc` or `.zprint.edn`.  If we don't
+find either, we will look in the parent of the current workspace
+for either file.  This continues until we find a file with either
+name, encounter the original configuration file in the user's home
+directory, or run out of directories.
+
+If `:search-config?` was not true but `:cwd-zprintrc?` was true,
+we will look for `.zprintrc` or `.zprint.edn` in the current workspace
+and use either if found.
+
+We will only every use one additional file beyond the file in the 
+user's home directory.
+
+Note that the files used will be listed in the extensions OUTPUT
+channel: "vscode-clj-zprint Messages".
+
+## Operation
+
+`zprint` can only successfully format "top level" expressions.  If
+you choose to format an entire file that isn't an issue.  To format
+less than an entire file, you can select any amount of code and
+when you format that selection, `zprint` will expand the range to
+encompass the minimal top level expression or expressions included 
+in the selection and format those.
+
+If you configure `vscode-clj-zprint` as the default formatter, you
+can simply hit the key-code CMD-K CMD-F (on Macos) and it will
+format the expression in which the cursor currently resides without
+you having to explicitly select anything.
+
+## Communication
+
+There is an channel in the OUTPUT for this extension: "vscode-clj-zprint
+Messages".  It is not necessary to examine it, but if you are
+wondering about the operation of the extension, you might find it
+useful.  If you submit an issue regarding this extension, including
+information from this channel would probably be helpful.
 
 ## Disclaimer
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:dependencies [[zprint "1.0.2"]]
+{:dependencies [[zprint "1.2.1"]]
 
  :source-paths ["src"]
 

--- a/src/vscode_clj_zprint/core.cljs
+++ b/src/vscode_clj_zprint/core.cljs
@@ -3,41 +3,228 @@
             ["fs" :as fs]
             ["os" :as os]
             [zprint.core :as zprint]
-            [cljs.reader :as reader]))
+            [zprint.config]
+            [clojure.string]))
+
+(def channel (vscode/window.createOutputChannel "vscode-clj-zprint Messages"))
+
+(defn output-message "Put a string into the channel." [message] (.appendLine channel message) nil)
 
 (defn slurp
   [file]
-  (->
-    (.readFileSync fs file "utf8")
-    (.toString)))
+  (-> (.readFileSync fs file "utf8")
+      (.toString)))
 
-(defn get-zprintrc-file-str
+(def zprintrc ".zprintrc")
+(def zprintedn ".zprint.edn")
+
+(defn get-config-from-file
+  "Read in an options map from a single file.  Returns [options-from-file
+  error-string filepath file-exists], where file-exists is non-nil
+  if we could open the file.  This allows us to distinguish between
+  file not found and errors reading the file."
+  [filepath]
+  (when filepath
+    (let [[file-str file-error]
+            (try [(slurp filepath) nil]
+                 (catch :default e
+                   [nil (str "Unable to open configuration file " filepath " because " e)]))]
+      (if file-error
+        [nil file-error filepath nil]
+        (try (let [opts-file (zprint.config/sci-load-string file-str)]
+               [opts-file nil filepath true])
+             (catch :default e
+               [nil (str "Unable to read configuration from file " filepath " because " e) filepath
+                true]))))))
+
+(defn find-found
+  "Find first file that was found.  Accepts a sequence of vectors
+  where the 4th element in the vectors is true if the file was
+  found."
+  [config-vec]
+  (reduce #(when (nth %2 3) (reduced %2)) config-vec))
+
+(defn get-config-from-path
+  "Take a vector of filenames, and look in exactly one directory
+  for all of the filenames.  Return the [option-map error-str
+  full-file-path] from get-config-from-file for the first one found,
+  nil if none were found and they were optional, or an error
+  referencing all of them if none were found and they weren't
+  optional."
+  [filename-vec file-sep dir-vec optional]
+  (let [dirspec (apply str (interpose file-sep dir-vec))
+        config-vec (reduce #(let [config (get-config-from-file %2)]
+                              (if (nth config 3) (reduced (conj %1 config)) (conj %1 config)))
+                     []
+                     (map (partial str dirspec file-sep) filename-vec))
+        found (find-found config-vec)]
+    (cond optional found
+          found found
+          :else [nil (str "Unable to load configuration from: " (mapv #(nth % 2) config-vec))
+                 nil])))
+
+(defn get-config-from-dirs
+  "Take a vector of directories dir-vec and check for all of the
+  filenames in filename-vec in the directories specified by dir-vec.
+  When one is found, return (using reduced) the [option-map error-str
+  full-file-path] from get-config-from-file, or nil if none are
+  found.  Will now accept fns from any of the files since using
+  sci/eval-string."
+  [filename-vec file-sep home-zprint-dir-vec dir-vec _]
+  (if (= home-zprint-dir-vec dir-vec)
+    ; Stop when we are about to do the home directory
+    (reduced nil)
+    (let [config-vec (get-config-from-path filename-vec file-sep dir-vec :optional)]
+      (if config-vec
+        ; Got it!
+        (reduced config-vec)
+        ; Try again, with one less directory in dir-vec
+        (into [] (butlast dir-vec))))))
+
+(defn scan-up-dir-tree
+  "Take a vector of filenames and scan up the directory tree from
+  the workspace-str to the root, looking for any of the files
+  in each directory.  Look for them in the order given in the vector.
+  Return nil or a vector from get-config-from-file: [option-map
+  error-str full-file-path] if one was found."
+  [filename-vec file-sep workspace-str home-zprint-file-path]
+  (let [; split either unix or windows file separators
+        ; theory is that we can always access files with unix
+        ; file separators, but we may get a path with either
+        ; and the fsPath for the workspace will have os specific
+        ; path separators according to the API
+        dirs-to-root (clojure.string/split workspace-str #"\\|/")
+        home-zprint-dir-vec (butlast (clojure.string/split home-zprint-file-path #"\\|/"))]
+    ; The reduce will run the fn once for each directory, and it
+    ; will trim one off each time it runs
+    (reduce (partial get-config-from-dirs filename-vec file-sep home-zprint-dir-vec)
+      dirs-to-root
+      dirs-to-root)))
+
+;!zprint {:fn-map {"str" :wrap}}
+(defn handle-errors-and-set-options!
+  "If we have options, do a zprint/set-options! and if it fails 
+  (probably due to an incorrect options map key), output the 
+  message to the extension's channel and continue. 
+  If there are errors, output those to the extensions channel.
+  Returns options when it works, nil otherwise."
+  [options errors filepath initial because]
+  (cond options (try (zprint/set-options! options)
+                     (output-message (str "Successfully loaded" (when initial (str " " initial " "))
+                                       "configuration options from '" filepath "'"
+                                       (when because (str " because " because)) "."))
+                     options
+                     (catch :default e
+                       (output-message (str "Unable to successfully set-options! on options from '"
+                                         filepath "' because: " e))))
+        errors (output-message errors)))
+
+(defn configure-home-zprint
+  "Configure the .zprintrc or .zprint.edn from the users home directory.
+  Return the filepath of the file, if any."
   []
-  (let [home-str (.homedir os)
-        workspace-zprintrc-file-str (str (.. (first vscode/workspace.workspaceFolders) -uri -fsPath) "/.zprintrc")
-        global-zprintrc-file-str (str home-str "/.zprintrc")]
-    (cond
-      (.existsSync fs workspace-zprintrc-file-str) workspace-zprintrc-file-str
-      (.existsSync fs global-zprintrc-file-str) global-zprintrc-file-str
-      :else nil)))
+  (let [home (.homedir os)
+        [options errors filepath] (when home
+                                    (get-config-from-path [zprintrc zprintedn] "/" [home] nil))]
+    (handle-errors-and-set-options! options errors filepath "initial" nil)
+    filepath))
+
+(defn get-workspace-str
+  "Find the current (or at least a current) workspace string.
+  Return nil if no current workspace."
+  []
+  (let [workspace (first vscode/workspace.workspaceFolders)]
+    (when workspace (.. ^js workspace -uri -fsPath))))
 
 (defn get-config!
+  "There are three steps in this process.  First, we attempt to
+  configure zprint from the ~/.zprintrc or ~/.zprint.edn in the
+  users home directory.  We log a message however that comes out.
+  Then, we look at :search-config? to see if we should look for
+  either .zprintrc or .zprint.edn in the current working directory
+  and above that unti we find a file.  Of course, we don't really
+  have a current working directory.  So we will use the first of
+  the workspaces we find, if any.  Then if :search-config? was
+  false, we check :cwd-zprintrc?.  If it is true, we look for
+  .zprintrc or .zprint.edn in the current workspace."
   []
-  (let [zprintrc-file-str (get-zprintrc-file-str)]
-    (try
-      (when zprintrc-file-str
-        (let [zprintrc-str (slurp zprintrc-file-str)]
-          (when zprintrc-str (reader/read-string zprintrc-str))))
-      (catch :default _ {}))))
+  (let [home-zprint-path (configure-home-zprint)
+        options (zprint.config/get-options)
+        cwd-zprintrc? (:cwd-zprintrc? options)
+        search-config? (:search-config? options)
+        need-workspace? (or cwd-zprintrc? search-config?)]
+    (when need-workspace?
+      (let [workspace-str (get-workspace-str)]
+        (if workspace-str
+          (cond
+            search-config?
+              (let [[options errors filepath]
+                      (scan-up-dir-tree [zprintrc zprintedn] "/" workspace-str home-zprint-path)]
+                (handle-errors-and-set-options! options
+                                                errors
+                                                filepath
+                                                "additional"
+                                                ":search-config? was true"))
+            cwd-zprintrc?
+              (let [[options errors filepath]
+                      (get-config-from-path [zprintrc zprintedn] "/" [workspace-str] :optional)]
+                (handle-errors-and-set-options! options
+                                                errors
+                                                filepath
+                                                "additional"
+                                                ":cwd-zprintrc? was true")))
+          (output-message
+            (str "No current workspace found, so cannot load additional configuration based on "
+              (cond search-config? "{:search-config? true}"
+                    cwd-zprintrc? "{:cwd-zprintrc? true}"))))))))
 
-(deftype ClojureDocumentRangeFormattingEditProvider [config]
- Object
-   (provideDocumentRangeFormattingEdits [_ ^js document range options token]
-     (let [text       (.getText document range)
-           path vscode/window.activeTextEditor.document.uri.fsPath
-           formatted (try (zprint/zprint-file-str text path config)
-                                (catch js/Error e (js/console.log (.-message e))))]
-       (when formatted #js [(vscode/TextEdit.replace range formatted)]))))
+(defn zprint-range->vscode-range
+  "Given a range of lines from zprint and the document from which
+  they were drawn, create a vscode range where the start is the
+  range that zprint reported formatting and the character position
+  of the start is zero.  The line number of the end is the line
+  number zprint formatted, and the character position is whatever
+  the rangeIncludingLineBreak uses.  Well, really, the
+  rangeIncludingLineBreak appears to be one larger than the line
+  number of the line from which it came, but that must be how
+  vscode handles line breaks."
+  [^js document start end]
+  (let [start-position (new vscode/Position start 0)
+        end-line (.lineAt document end)
+        end-position-ilb end-line.rangeIncludingLineBreak.end]
+    (new vscode/Range start-position end-position-ilb)))
+
+;!zprint {:fn-map {"str" :wrap}}
+(deftype ^js ClojureDocumentRangeFormattingEditProvider []
+  Object
+    (provideDocumentRangeFormattingEdits [_ ^js document range options token]
+      (let [text (.getText document)
+            start-line range.start.line
+            end-line range.end.line
+            ; The API docs say not to use fsPath for display purposes
+            ; so we will use path instead
+            path vscode/window.activeTextEditor.document.uri.path
+            [zprint-range formatted]
+              (try
+                (zprint/zprint-file-str text
+                                        path
+                                        {:input {:range {:start start-line, :end end-line}},
+                                         :output {:range? true}})
+                (catch js/Error e (output-message (str "Unable to format text: " (.-message e)))))]
+        (when zprint-range
+          (let [actual-start (:actual-start (:range zprint-range))
+                actual-end (:actual-end (:range zprint-range))
+                range-to-replace (when formatted
+                                   (zprint-range->vscode-range document actual-start actual-end))]
+            (output-message
+              (if formatted
+                (str "Successfully formatted. Selected/Actual/Replaced:[" start-line "," end-line
+                  "]/[" actual-start "," actual-end "]/[(" range-to-replace.start.line ","
+                  range-to-replace.start.character "),(" range-to-replace.end.line ","
+                  range-to-replace.end.character ")] in file: '" path "'")
+                (str "No format performed. Selected/Actual:[" start-line "," end-line "]/["
+                  actual-start "," actual-end "] in file: '" path "'")))
+            (when formatted #js [(vscode/TextEdit.replace range-to-replace formatted)]))))))
 
 (defn register-disposable
   [^js context ^js disposable]
@@ -52,9 +239,8 @@
 
 (defn activate
   [^js context]
-  (let [config   (get-config!)
-        provider (ClojureDocumentRangeFormattingEditProvider. config)]
+  (get-config!)
+  (let [provider (ClojureDocumentRangeFormattingEditProvider.)]
     (dispose context
-             (vscode/languages.registerDocumentRangeFormattingEditProvider
-              document-selector
-              provider))))
+             (vscode/languages.registerDocumentRangeFormattingEditProvider document-selector
+                                                                           provider))))


### PR DESCRIPTION
First, let me say that I'm both very impressed as well as excited that you have created this extension.   I have never used vscode before, but I've used it enough in developing these changes that I'm considering moving to using it all the time.  I wouldn't even consider doing that if you hadn't developed this extension.  So thank you personally for doing this, as well as thank you for other folks who use zprint that would like to use VSCode and not lose the capability of using zprint.

So, I started working on the extension to get the configuration to match up to zprint's.  As I was testing it, I found some things that were annoying about how zprint integrated with vscode when actually formatting code.  I tried working with the extension and got things to work better, but ultimately I realized that I could make what seemed like a simple addition to zprint to help the integration with vscode.  Of course it wasn't all that simple in the actual doing of it, but ultimately what came out of it seems pretty solid, both for zprint and in the extension.

Details...

I created an output channel for the extension, so if you look in OUTPUT "vscode-clj-zprint Messages" you can see some status for what was configured and what is going on.  I used this for debugging, but it seems like it is also useful in case people need to see what is happening.  It isn't intrusive, but it is there if you need it.

Configuration changes:

The zprint configuration approach is to always configure `~/.zprintrc`, and if it isn't found, try to configure `~/.zprint.edn`.  That's it unless either `{:search-config? true}` or `{:cwd-zprintrc? true}` is set in one of those files.  If `:search-config?` is true, then zprint looks for a `.zprintrc` or .`zprint.edn` in the current working directory, and if it doesn't find either, it looks one directory up from that, and continues until it either finds a file, or runs out of directories, or runs into the `~/.zprintrc` or `~/.zprint.edn`.  If `:search-config?` is not true, then if `:cwd-zprintrc?` is true, then zprint looks for a `.zprintrc` or `.zprint.edn` in the current working directory.

I have tried to replicate that as much as possible in the extension. Of course, there isn't actually a current working directory.  So I've used the first workspace as the substitute for the current working directory -- if there is one.  If there isn't a current workspace but either `:search-config?` or` :cwd-zprintrc?` was true, then a message is output onto the extensions channel.

Every file from which the extension configures an options map is noted in the extension's channel, so there is no doubt about what was used -- if you want to look at it.

Additionally, the extension now uses `(set-options! ...)` to set the options into zprint so that they don't have to be validated and interpreted on each invocation.

Also, the option maps are read in through `sci`, the "small Clojure intepreter", which ensures that things that are executable don't break out and affect the world outside of zprint.

Execution changes:

Having gotten the configuration to match the way zprint configures as much as possible, I found that it worked fine if I selected an entire top level expression and formatted it, or if I did a whole file (document).  But if I missed a bit on the selection it mostly didn't work.  This seemed annoying. 

Some years ago someone wanted to use zprint to format just a range of lines in a file, and so I built that capability into zprint.  If you give zprint an options map:` {:input {:range {:start n :end m}}}` zprint will take the start and end and expand them out to cover the minimal top level expression or expressions that are within the `:start` and `:end`.

It seemed like giving the lines selected by the user to zprint as a zprint range and letting it figure out the top level expressions would make using the extension more satisfying.  Indeed it did, but the problem was that zprint would always return the entire document, with just the lines in that range formatted.  Which was ok, I could just replace the entire document.  But that seemed like kind of a hack, and possibly lower performance if the file was large.

zprint clearly knew internally what the actual start and end were for what it formatted, but it didn't have any way to communicate that information.  So I enhanced zprint to optionally output the actual start and end of what it formatted, as well as just the lines it formatted (instead of the whole file).  This is triggered by `{:output {:range? true}}`.

I released a new version of zprint, `1.2.1`, with this capability in it earlier this week.  I then used this in the extension.  An interesting consequence of this approach is that if you have your cursor sitting inside of a function, and you hit CMD-K CMD-F the extension will format just that function, without moving the cursor.  Of course `vscode-clj-zprint` has to be the default formatter.

Personally, I find this behavior very attractive, since I don't have to select anything to get it to format what I'm working on.

That's pretty much where I've left the extension at this point.

I hope you like it. I'm really sorry I didn't get this to you earlier, but there it is.  Let me know what you think.