### PR TITLE
Allow zprint configuration within vscode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.0.3
+
+- Follows zprint interpretation of `.zprintrc` and `.zprint.edn` files as closely as possible.
+- Automatically expands any selection to encompass "top-level" expressions.
+- Can configure extension directly in VSCode -- doesn't require external files.
+
+## v0.0.2
+
 ## v0.0.1
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 
 A VS Code wrapper for [clj-zprint](https://github.com/kkinnear/zprint) written in `cljs`, built with [Shadow CLJS](http://shadow-cljs.org/).
 
-
 ## Configuration
 
-Configuration follows `zprint` as closely as possible.  First, we look
-for a `.zprintrc` or `.zprint.edn` in the user's home directory.
-Either will be used, if found.  If neither are found, configuration
-is complete.  If either are found, configuration continues.
+### External Configuration (`.zprintrc` and `.zprint.edn`)
+
+By default, the extension will configure zprint from the normal
+zprint configuration files, allowing you to use zprint within vscode
+and zprint outside of vscode with the same zprint configuration.
+
+You can configure the extension to ignore the external zprint
+configuration files, see the next section for how to do this.
+
+If you don't configure the extension to ignore the zprint configuration
+files, then configuration follows zprint as closely as possible.
+First, we look for a `.zprintrc` or `.zprint.edn` in the user's
+home directory.  Either will be used, if found.  If neither are
+found, configuration is complete.  If either are found, configuration
+continues if there is a current workspace.  If there is not a current
+workspace, then an error is shown in a popup and logged in the
+`vscode-clj-zprint Messages` OUTPUT channel.
 
 If `:search-config?` is true then we will look in the current
 workspace for either a `.zprintrc` or `.zprint.edn`.  If we don't
@@ -17,15 +29,139 @@ for either file.  This continues until we find a file with either
 name, encounter the original configuration file in the user's home
 directory, or run out of directories.
 
-If `:search-config?` was not true but `:cwd-zprintrc?` was true,
+If `:search-config?` is not true but `:cwd-zprintrc?` is true,
 we will look for `.zprintrc` or `.zprint.edn` in the current workspace
 and use either if found.
 
-We will only every use one additional file beyond the file in the 
+We will only ever use one additional file beyond the file in the 
 user's home directory.
 
 Note that the files used will be listed in the extensions OUTPUT
-channel: "vscode-clj-zprint Messages".
+channel: `vscode-clj-zprint Messages`.
+
+Once the external configuration is completed successfully, any changes
+to the external configuration files will not be noticed by the
+extension until either the VSCode configuration changes or the
+command `Zprint: Refresh Configuration` is executed.  See `Commands`
+below for details.
+
+If there are any configuration errors in the external files, the
+entire configuration process (including reading any external files)
+will be repeated on every use of the extension until the errors
+are fixed.
+
+### VSCode Configuration
+
+There are a number of configuration options within VSCode to allow
+you to configure zprint.  You can use these options to extend the
+zprint configuration found in the external configuration files (if
+any), or you can explicity configure the extension to ignore any
+zprint external configuration files.  Then all of zprint's configuration
+will be held in the VSCode Configuration for this extension.
+
+The VSCode configuration is available in the VSCode `Settings`, under 
+`Extensions`>`Zprint`
+
+Every time the extension is used, it will check the VSCode configuration
+and if it has changed, the extension will erase any current zprint
+configuration, load any external configuration files (unless configured
+to not do so), and then load the current VSCode configuration.
+There is no need to use the command `Zprint: Refresh Configuration`
+after changing the VSCode zprint configuration -- any changes are
+detected automatically.
+
+#### Ignore External Files
+
+If you check this box, the extension will not examine any zprint
+configuration files -- it will not read any `.zprintrc` or
+`.zprint.edn` files.  Default: _unchecked_
+
+#### Community Formatting
+
+If you check this box, the zprint style `:community` will be configured
+after any styles specified in the external files and before any styles
+configured in the VSCode configuration.  This will configure zprint
+to use the "Community Formatting" guidelines for Clojure.
+Default: _unchecked_
+
+#### Options Map 
+
+A (potentially multi-line) string field into which you can enter 
+a zprint options map in EDN format.  Any valid zprint options map will
+be acceptable.  It will be applied after the option maps resulting from
+any external configuration files, and after all other options from the
+VSCode zprint configuration.
+
+#### Styles: Array Of Styles
+
+An array of strings, where each string must be a keyword that references
+a zprint style.  You could reference a style defined in the `Options Map`,
+above, since both of these configuration elements are placed into a single
+options map.
+
+#### Styles: Use Only These Styles
+
+If you want the `Array Of Styles` to be the only styles used, then
+you should check this box.  Any styles configured using the `:style`
+key in the zprint external configuration files (if any) are ignored,
+as are any styles configured using the `:style` key in the `Options Map` 
+VSCode configuration as well as the `Community Formatting`
+checkbox. Default: _unchecked_
+
+#### Width
+
+This will set the width of the zprint formatting within VSCode.
+A null string, the default, will be ignored.  Any positive value
+will be used as the width of the formatting.  A `:width` configured
+in the `Options Map` will override a width configured here.
+
+### Error Handling
+
+There are (at most) three distinct groups of configuration options 
+that can configure zprint.  Two possible external configuration
+files and the internal VSCode configuration.
+
+In each case, there are two points where errors can appear.  The
+configuration options themselves might be incorrectly formatted or
+otherwise be syntactically incorrect, or they might be rejected by
+zprint because they didn't pass validation successfully.
+
+If any of the three groups of configuration options has either of
+these failures, that set of options will not be loaded into zprint
+but the other two groups will nevertheless be configured (only if,
+of course, they had no problems themselves).
+
+All errors will be signalled in two ways -- a popup will appear and
+the equivalent information will also be logged in the 
+`vscode-clj-zprint Messages` channel of OUTPUT.
+
+Any errors will cause the configuration process to retried
+from scratch at the next use of the extension.  This will continue
+until the errors go away.  Thus, if there are errors in one
+of the `.zprintrc` or `.zprint.edn` files, they will continue
+to be read on each use of the extension until the errors
+are fixed, at which time they will be read once more and then
+not examined again until a VSCode configuration element changes
+or the `Zprint: Refresh Configuration` command is executed.
+
+### Commands
+
+The following commands are available in VSCode in the `Command Pallet`.
+Note that these commands are not available until a Clojure or Clojurescript
+file is selected.
+
+#### Zprint: Refresh Configuration
+
+This command will cause the extension to re-read any external 
+configuration.  You would trigger this command whenever you might
+change any `.zprintrc` or `.zprint.edn` external configuration
+files.
+
+#### Zprint: Output Current non-Default Configuration
+
+This command will cause all zprint configuration options which are
+not currently set to their default vales to be output to the OUTPUT
+on the channel `vscode-clj-zprint Messages`.
 
 ## Operation
 
@@ -41,10 +177,11 @@ can simply hit the key-code CMD-K CMD-F (on Macos) and it will
 format the expression in which the cursor currently resides without
 you having to explicitly select anything.
 
+
 ## Communication
 
-There is an channel in the OUTPUT for this extension: "vscode-clj-zprint
-Messages".  It is not necessary to examine it, but if you are
+There is an channel in the OUTPUT for this extension: `vscode-clj-zprint
+Messages`.  It is not necessary to examine it, but if you are
 wondering about the operation of the extension, you might find it
 useful.  If you submit an issue regarding this extension, including
 information from this channel would probably be helpful.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-clj-zprint",
     "displayName": "vscode-clj-zprint",
     "description": "Wrapper for clj-zprint to format Clojure code.",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "rflagreca",
     "repository": "https://github.com/rflagreca/vscode-clj-zprint",
     "license": "GPL-3.0-or-later",
@@ -13,10 +13,84 @@
         "Formatters"
     ],
     "activationEvents": [
-        "onLanguage:clojure"
+        "onLanguage:clojure",
+        "onCommand:vscode-clj-zprint.refresh",
+        "onCommand:vscode-clj-zprint.currentconfig"
     ],
     "main": "./extension.js",
     "contributes": {
+        "commands": [
+            {
+              "command": "vscode-clj-zprint.refresh",
+              "title": "Zprint: Refresh Configuration"
+            },
+            
+            {
+              "command": "vscode-clj-zprint.currentconfig",
+              "title": "Zprint: Output Current non-Default Configuration"
+            }
+          ],
+        "menus": {
+            "commandPalette": [
+              {
+                "command": "vscode-clj-zprint.refresh",
+                "when": "editorLangId == clojure"
+              },
+              
+              {
+                "command": "vscode-clj-zprint.currentconfig",
+                "when": "editorLangId == clojure"
+              }
+
+            ]
+        },
+        
+        "configuration": {
+            "title": "Zprint",
+            "properties": {
+              "vscode-clj-zprint.width": {
+                "type": "string",
+                "default": null,
+                "description": "Width to format code. If no value, ignored."
+              },
+            
+              "vscode-clj-zprint.Styles.ArrayOfStyles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": null,
+                "description": "Specify styles, which will be applied in the order given."
+              },
+              
+              "vscode-clj-zprint.Styles.UseOnlyTheseStyles": {
+                "type": "boolean",
+                "default": false,
+                "markdownDescription": "Ignore any `:style` configured in external files and use only the styles specified in the `Array Of Styles`.  `Community Formatting` will be ignored, as will any `:style` in the `Option Map`."
+              },
+
+              "vscode-clj-zprint.CommunityFormatting": {
+                "type": "boolean",
+                "default": false,
+                "markdownDescription": "Use community formatting approach.  Adds the `:community` style."
+              },
+              
+              "vscode-clj-zprint.IgnoreExternalFiles": {
+                "type": "boolean",
+                "default": false,
+                "markdownDescription": "Do not read any `.zprintrc` or `.zprint.edn` files."
+              },
+
+              "vscode-clj-zprint.OptionsMap": {
+                "type": "string",
+                "editPresentation": "multilineText",
+                "default": null,
+                "description": "Enter a properly formatted options map. It will be applied after all other configuration."
+              }
+
+           }
+
+        }
     },
     "scripts": {
         "lint": "eslint .",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:dependencies [[zprint "1.2.1"]]
+{:dependencies [[zprint "1.2.2"]]
 
  :source-paths ["src"]
 

--- a/src/vscode_clj_zprint/core.cljs
+++ b/src/vscode_clj_zprint/core.cljs
@@ -4,11 +4,91 @@
             ["os" :as os]
             [zprint.core :as zprint]
             [zprint.config]
-            [clojure.string]))
+            [clojure.string]
+            [clojure.edn]))
 
 (def channel (vscode/window.createOutputChannel "vscode-clj-zprint Messages"))
 
-(defn output-message "Put a string into the channel." [message] (.appendLine channel message) nil)
+; Data storage for raw configuration information from vscode
+
+(def config-map-save (atom {}))
+
+(def vscode-options-map (atom {}))
+(def configured? (atom false))
+
+; Message Handling Functions
+
+(defn output-message
+  "Put a string into the channel.  Returns nil."
+  [message]
+  (.appendLine channel message)
+  nil)
+
+(defn error-message
+  "Output an error message popup as well as a message into the channel.
+   es is the value for showErrorMessage, and os (if it appears) is the
+   string for output-message.  If there is no os, then es is used.
+   Returns non-nil."
+  ([error-str output-str]
+   (vscode/window.showErrorMessage error-str)
+   (output-message output-str)
+   error-str)
+  ([s] (error-message s s)))
+
+;!zprint {:format :next :fn-map {"str" :wrap}}
+(defn handle-errors-and-set-options!
+  "If we have options, do a zprint/set-options! and if it fails 
+  (probably due to an incorrect options map key), output the 
+  message to the extension's channel and continue. 
+  If there are errors, output those to the extensions channel.
+  Returns nil when it succeeds, non-nil for failure."
+  [options errors filepath remove-style? initial because]
+  (cond options (try
+                  (zprint/set-options! (if remove-style? (dissoc options :style) options) filepath)
+                  (output-message (str "Successfully loaded" (when initial (str " " initial " "))
+                                    "configuration options from '" filepath "'"
+                                    (when because (str " because " because)) "."))
+                  (catch :default e
+                    (error-message (str e)
+                                   (str "Unable to successfully set-options! on options from '"
+                                     filepath "' because: " e))))
+        errors (error-message errors)))
+
+; Utility Functions
+
+(defn concat-errors
+  "Given a vector containings strings or nil, produce a string
+  with the non-empty strings separated by semicolons, and an
+  introduction as to how many errors were found if there were
+  more than one.  If none of the strings are not empty, return 
+  nil."
+  [str-vec]
+  (let [no-nil-seq (remove nil? str-vec)
+        no-empty-seq (remove empty? no-nil-seq)
+        comma-seq (interpose "; " no-empty-seq)
+        error-count (count no-nil-seq)]
+    (cond (zero? error-count) nil
+          (= error-count 1) (apply str comma-seq)
+          :else (str "Found the following " error-count
+                     " distinct errors: " (apply str comma-seq)))))
+
+(defn number-or-nil
+  "Given a string value, if the string is empty return the value
+   as nil, if it is non-empty read it as a number.  Returns
+   [value errors]"
+  [s field-name]
+  (let [n (clojure.edn/read-string s)
+        errors (if (or (nil? n) (number? n))
+                 nil
+                 (str "The value of '"
+                      field-name
+                      "' must be a number or empty, instead found: '"
+                      n
+                      "'."))
+        n (when (not errors) n)]
+    [n errors]))
+
+; External Configuration Functions
 
 (defn slurp
   [file]
@@ -48,9 +128,10 @@
   "Take a vector of filenames, and look in exactly one directory
   for all of the filenames.  Return the [option-map error-str
   full-file-path] from get-config-from-file for the first one found,
-  nil if none were found and they were optional, or an error
-  referencing all of them if none were found and they weren't
-  optional."
+  nil if none were found and they were optional, or an warning
+  is output directly referencing all of them if none were found 
+  and they weren't optional.  No error is returned in this case,
+  since this is only a warning."
   [filename-vec file-sep dir-vec optional]
   (let [dirspec (apply str (interpose file-sep dir-vec))
         config-vec (reduce #(let [config (get-config-from-file %2)]
@@ -60,8 +141,9 @@
         found (find-found config-vec)]
     (cond optional found
           found found
-          :else [nil (str "Unable to load configuration from: " (mapv #(nth % 2) config-vec))
-                 nil])))
+          :else (do (output-message (str "Unable to load external configuration. Files not found: " 
+                                         (mapv #(nth % 2) config-vec)))
+                    [nil nil nil]))))
 
 (defn get-config-from-dirs
   "Take a vector of directories dir-vec and check for all of the
@@ -88,10 +170,10 @@
   Return nil or a vector from get-config-from-file: [option-map
   error-str full-file-path] if one was found."
   [filename-vec file-sep workspace-str home-zprint-file-path]
-  (let [; split either unix or windows file separators
-        ; theory is that we can always access files with unix
-        ; file separators, but we may get a path with either
-        ; and the fsPath for the workspace will have os specific
+  (let [; Split on either unix or windows file separators.
+        ; The theory is that we can always access files with unix
+        ; file separators, but we may get a path with either.
+        ; The fsPath for the workspace will have os specific
         ; path separators according to the API
         dirs-to-root (clojure.string/split workspace-str #"\\|/")
         home-zprint-dir-vec (butlast (clojure.string/split home-zprint-file-path #"\\|/"))]
@@ -101,33 +183,15 @@
       dirs-to-root
       dirs-to-root)))
 
-;!zprint {:fn-map {"str" :wrap}}
-(defn handle-errors-and-set-options!
-  "If we have options, do a zprint/set-options! and if it fails 
-  (probably due to an incorrect options map key), output the 
-  message to the extension's channel and continue. 
-  If there are errors, output those to the extensions channel.
-  Returns options when it works, nil otherwise."
-  [options errors filepath initial because]
-  (cond options (try (zprint/set-options! options)
-                     (output-message (str "Successfully loaded" (when initial (str " " initial " "))
-                                       "configuration options from '" filepath "'"
-                                       (when because (str " because " because)) "."))
-                     options
-                     (catch :default e
-                       (output-message (str "Unable to successfully set-options! on options from '"
-                                         filepath "' because: " e))))
-        errors (output-message errors)))
-
 (defn configure-home-zprint
   "Configure the .zprintrc or .zprint.edn from the users home directory.
   Return the filepath of the file, if any."
-  []
+  [remove-style?]
   (let [home (.homedir os)
         [options errors filepath] (when home
                                     (get-config-from-path [zprintrc zprintedn] "/" [home] nil))]
-    (handle-errors-and-set-options! options errors filepath "initial" nil)
-    filepath))
+    [filepath
+     (handle-errors-and-set-options! options errors filepath remove-style? "initial" nil)]))
 
 (defn get-workspace-str
   "Find the current (or at least a current) workspace string.
@@ -136,7 +200,7 @@
   (let [workspace (first vscode/workspace.workspaceFolders)]
     (when workspace (.. ^js workspace -uri -fsPath))))
 
-(defn get-config!
+(defn get-external-config!
   "There are three steps in this process.  First, we attempt to
   configure zprint from the ~/.zprintrc or ~/.zprint.edn in the
   users home directory.  We log a message however that comes out.
@@ -146,48 +210,191 @@
   have a current working directory.  So we will use the first of
   the workspaces we find, if any.  Then if :search-config? was
   false, we check :cwd-zprintrc?.  If it is true, we look for
-  .zprintrc or .zprint.edn in the current workspace."
-  []
-  (let [home-zprint-path (configure-home-zprint)
+  .zprintrc or .zprint.edn in the current workspace. If remove-style?
+  is true, we remove any styles from any configuration files we
+  find before we do the set-options! for them.  Returns nil for
+  success, non-nil for failure."
+  [remove-style?]
+  (let [[home-zprint-path home-zprint-errors] (configure-home-zprint remove-style?)
         options (zprint.config/get-options)
         cwd-zprintrc? (:cwd-zprintrc? options)
         search-config? (:search-config? options)
         need-workspace? (or cwd-zprintrc? search-config?)]
-    (when need-workspace?
+    (if need-workspace?
       (let [workspace-str (get-workspace-str)]
         (if workspace-str
           (cond
             search-config?
               (let [[options errors filepath]
                       (scan-up-dir-tree [zprintrc zprintedn] "/" workspace-str home-zprint-path)]
-                (handle-errors-and-set-options! options
-                                                errors
-                                                filepath
-                                                "additional"
-                                                ":search-config? was true"))
+                (or (handle-errors-and-set-options! options
+                                                    errors
+                                                    filepath
+                                                    remove-style?
+                                                    "additional"
+                                                    ":search-config? was true")
+                    home-zprint-errors))
             cwd-zprintrc?
               (let [[options errors filepath]
                       (get-config-from-path [zprintrc zprintedn] "/" [workspace-str] :optional)]
-                (handle-errors-and-set-options! options
-                                                errors
-                                                filepath
-                                                "additional"
-                                                ":cwd-zprintrc? was true")))
-          (output-message
+                (or (handle-errors-and-set-options! options
+                                                    errors
+                                                    filepath
+                                                    remove-style?
+                                                    "additional"
+                                                    ":cwd-zprintrc? was true")
+                    home-zprint-errors)))
+          ; There may be other errors, but we only need to return one if there
+          ; are any since it is only that there is one, not the specific error
+          ; that matters.
+          (error-message
             (str "No current workspace found, so cannot load additional configuration based on "
-              (cond search-config? "{:search-config? true}"
-                    cwd-zprintrc? "{:cwd-zprintrc? true}"))))))))
+                 (cond search-config? "{:search-config? true}"
+                       cwd-zprintrc? "{:cwd-zprintrc? true}")))))
+      ; We didn't need a workspace
+      home-zprint-errors)))
+
+; VS Code configuration functions
+
+(defn create-style-vec
+  "Given a string with a comma separated set of styles, create
+   a vector with each style as a separate keyword. Returns
+   [style-vec errors] where only one of them is non-nil."
+  [style-str]
+  (let [split-vec (clojure.string/split style-str #"\,")
+        replaced (apply str (interpose " " split-vec))
+        style-vec-str (str "[" replaced "]")
+        keyword-vec (clojure.edn/read-string style-vec-str)]
+    (if (some false? (mapv keyword? keyword-vec))
+      [nil (str "Some of these styles in the 'Array of Styles' are not keywords: '" style-str "'")]
+      [keyword-vec nil])))
+
+(defn build-vscode-options-map
+  "Given the config-map, create and save a new vscode-options-map.
+  Note that this does not save the config-map, only the newly
+  constructed vscode-options-map if there are no errors.  It
+  also does not do the set-options! for the newly constructed map.
+  Returns [new-map errors].  If there are any errors, perhaps in
+  handling the array of styles, reading the options map, or converting
+  the width into a string, return the errors and the new-map as
+  nil."
+  [config-map]
+  (let [[keyword-vec style-errors] (create-style-vec (:array-of-styles config-map))
+        remove-style? (:use-only-these-styles config-map)
+        ; No community formatting if they checked "Use Only These Styles"
+        community-formatting? (when (not remove-style?) (:community-formatting config-map))
+        [width width-errors] (number-or-nil (:width config-map) "Width")
+        [options-map options-errors]
+          (try (let [opts-map (zprint.config/sci-load-string (:options-map config-map))]
+                 [opts-map nil])
+               (catch :default e
+                 [nil
+                  (str "Unable to read VS Code config entry 'Options Map' because '"
+                       (or (ex-message e) e)
+                       "'")]))
+        errors (concat-errors [style-errors width-errors options-errors])]
+    (if errors
+      (do
+        ; If we have VS Code errors, then we aren't going to have a new
+        ; vscode-options-map, so we need to forget the existing one!
+        (reset! vscode-options-map {})
+        [nil (error-message errors)])
+      (let [style-vec (into [] (concat (if community-formatting? [:community] []) keyword-vec))
+            explicit-map {:style style-vec}
+            ; Only the use :width if it is not nil.
+            explicit-map (if width (assoc explicit-map :width width) explicit-map)
+            ; If they checked "Use Only These Styles" then the only styles they
+            ; get are the styles in the arrar-of-styles.
+            options-map (if remove-style? (dissoc options-map :style) options-map)
+            new-map (zprint.config/merge-deep explicit-map options-map)]
+        (reset! vscode-options-map new-map)
+        [new-map nil]))))
+
+(defn create-vscode-options-map
+  "If the configuration has changed, then create an updated
+  configurations options map. Any errors from creating the map will
+  be output, and no map will be returned.  
+  Returns [new-map config-map remove-style? ignore-external-files? errors]"
+  []
+  (let [configuration (vscode/workspace.getConfiguration "vscode-clj-zprint")
+        ; Entire configuration as map, not a valid options map
+        ; Data types are ???
+        config-map {:width configuration.width,
+                    :array-of-styles configuration.Styles.ArrayOfStyles,
+                    :options-map configuration.OptionsMap,
+                    :use-only-these-styles configuration.Styles.UseOnlyTheseStyles,
+                    :community-formatting configuration.CommunityFormatting,
+                    :ignore-external-files configuration.IgnoreExternalFiles}
+        remove-style? (:use-only-these-styles config-map)
+        ignore-external-files? (:ignore-external-files config-map)]
+    ; Have any of the configuration elements changed since we last came through?
+    (if (not= config-map @config-map-save)
+      ; Things have changed, build a new options map
+      (let [[new-map errors] (build-vscode-options-map config-map)]
+        ; If we got a new map, then it was updated and so we should also update the
+        ; raw data.
+        [new-map config-map remove-style? ignore-external-files? errors])
+      [nil config-map remove-style? ignore-external-files? nil])))
+
+; One approach would be to hold the VS Code config as a options map outside of
+; zprint's set-options! and send it in on every zprint-file-str call.  Then,
+; when it changed, we wouldn't have to go back and remove the entire zprint
+; configuration and reload the option files.  Except that the VS Code config
+; says a lot about what we need to do with the zprint configuration read in
+; from the .zprintrc or .zprint.edn files.  So we need to start from scratch
+; every time the VS Code configuration changes.  Or at least when most of the
+; VS Code configuration elements change.  Also, placing the VS Code config
+; into zprint by using set-option! means that we can see what was actually
+; configured by using the "Zprint: Output Current non-Default Configuration"
+; command.  This command can be a huge help in trying to figure out what is
+; actually being given to zprint when complex configuration is in play.
+
+(defn update-configuration-if-needed
+  "Update the zprint configuration from the VS Code configuration element."
+  ([force-update?]
+   (let [[new-map config-map remove-style? ignore-external-files? vscode-errors]
+           (create-vscode-options-map)]
+     ; Do this if we have a vscode config change or if someone forces us to do it anyway
+     (when (or new-map vscode-errors force-update?)
+       ; Remove current configuration
+       (zprint.config/config-configure-all!)
+       (when @configured? (output-message "Removed existing zprint configuration."))
+       (let [external-errors (if ignore-external-files?
+                               (output-message
+                                 "Configured to ignore external .zprintrc and .zprint.edn files.")
+                               (get-external-config! remove-style?))]
+         (try (zprint/set-options! @vscode-options-map "VS Code config")
+              (when (and new-map @configured?) (output-message "Detected change in VS Code config."))
+              (output-message "Successfully updated zprint options map with VS Code config.")
+              (reset! configured? true)
+              ; Since the set-options! above worked, we can save the configuration
+              ; (i.e., the config-map) so we don't try to do it again next time.
+              ; If it doesn't work, we don't save the config-map so that each time
+              ; we compare the current VS Code config and the saved config-map they
+              ; look different, so that we will keep trying (and generating
+              ; showErrorMessages to the user) so that they eventually correct the
+              ; problem.  Or at least they know that something isn't right.
+              ;
+              ; If we didn't have any external errors, then if we get here we
+              ; have also not had any internal configuration errors, so we can
+              ; save the config-map.   This means that if we have any external
+              ; or internal errors of any sort, we will continually try to set
+              ; all of the configuration and display all of the errors each and
+              ; every time.
+              (when (not (or external-errors vscode-errors)) (reset! config-map-save config-map))
+              (catch :default e (error-message (str e))))))))
+  ([] (update-configuration-if-needed nil)))
 
 (defn zprint-range->vscode-range
   "Given a range of lines from zprint and the document from which
-  they were drawn, create a vscode range where the start is the
+  they were drawn, create a VS Code range where the start is the
   range that zprint reported formatting and the character position
   of the start is zero.  The line number of the end is the line
   number zprint formatted, and the character position is whatever
   the rangeIncludingLineBreak uses.  Well, really, the
   rangeIncludingLineBreak appears to be one larger than the line
-  number of the line from which it came, but that must be how
-  vscode handles line breaks."
+  number of the line from which it came, but that must be how VS Code
+  handles line breaks."
   [^js document start end]
   (let [start-position (new vscode/Position start 0)
         end-line (.lineAt document end)
@@ -195,9 +402,11 @@
     (new vscode/Range start-position end-position-ilb)))
 
 ;!zprint {:fn-map {"str" :wrap}}
+#_{:clj-kondo/ignore [:unused-binding :clojure-lsp/unused-public-var]}
 (deftype ^js ClojureDocumentRangeFormattingEditProvider []
   Object
     (provideDocumentRangeFormattingEdits [_ ^js document range options token]
+      (update-configuration-if-needed)
       (let [text (.getText document)
             start-line range.start.line
             end-line range.end.line
@@ -210,7 +419,7 @@
                                         path
                                         {:input {:range {:start start-line, :end end-line}},
                                          :output {:range? true}})
-                (catch js/Error e (output-message (str "Unable to format text: " (.-message e)))))]
+                (catch js/Error e (error-message (str "Unable to format text: " (.-message e)))))]
         (when zprint-range
           (let [actual-start (:actual-start (:range zprint-range))
                 actual-end (:actual-end (:range zprint-range))
@@ -237,10 +446,31 @@
 
 (def document-selector #js {:language "clojure"})
 
+(defn refresh-command-handler
+  "Refresh the zprint configuration, presumably because it
+   may have changed externally to VS Code."
+  []
+  (output-message (str "Zprint: Refresh Configuration"))
+  ; Force complete configuration update
+  (update-configuration-if-needed :force-update))
+
+(defn current-config-command-handler
+  "Output the current non-default configuration information"
+  []
+  (update-configuration-if-needed)
+  (output-message (str "Zprint: Output Current non-Default Configuration\n"
+                    (zprint/zprint-str (zprint.config/get-explained-set-options)))))
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn activate
   [^js context]
-  (get-config!)
-  (let [provider (ClojureDocumentRangeFormattingEditProvider.)]
-    (dispose context
-             (vscode/languages.registerDocumentRangeFormattingEditProvider document-selector
-                                                                           provider))))
+  (update-configuration-if-needed :force-update)
+  (let [provider (ClojureDocumentRangeFormattingEditProvider.)
+        refresh-command "vscode-clj-zprint.refresh"
+        current-config-command "vscode-clj-zprint.currentconfig"]
+    (dispose
+      context
+      (vscode/languages.registerDocumentRangeFormattingEditProvider document-selector provider)
+      (vscode/commands.registerCommand refresh-command refresh-command-handler)
+      (vscode/commands.registerCommand current-config-command current-config-command-handler))))
+


### PR DESCRIPTION
Here is what I think makes sense for VS Code configuration.  

It is mostly what I discussed in the issue I raised.  After having done some of it and experimenting with it, I changed some things around a bit.  I also added some things so that people could ignore the external `.zprintrc` and `.zprint.edn` files and configure everything in VS Code, which I think some people might want.

I wrote up what I think is complete documentation in the `README.md`, so it probably makes sense for you to just look at that and see what you think as opposed to me replicating it here in the PR.

I also changed the version to `0.0.3`, and did a minor update to the `CHANGELOG.md` as well. There wasn't much to go on, so I don't know how you want to handle those things, but I wanted to make sure that we didn't forget about them (as I did on the previous PR).

I have released the new version of zprint where the style configuration isn't broken, and on which the extension is based.

Overall it turned out to be a surprising amount of code, in no small part because I worked hard to get the user experience to be the best I could.  I was pleased to figure out how to get error messages to show up on the screen, so now if there are problems, while they still show up in the messages channel, they also show up on the screen and you can't really avoid knowing about them.  Mostly they continue to show up everytime you use the extension until you make
them go away.  Which seemed kind of "in your face", but better than just believing that you have things configured and not having zprint actually using the configuration.

Anyway, this was pretty much everything that seemed to make sense to me for people to configure in VS Code.  If you have other things and would like me to add them, I'd be happy to do so.  I considered something to allow configuration of the `:fn-map`, but some clever VS Code UI for that seemed less useful than just giving people an `Options Map` where they could configure it directly.  And of course the `Options Map` is much more general, so they can change anything.

Thanks for sharing your extension.  It has been a lot of fun to extend it!