### PR TITLE
Update zprint to v1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "compile": "yarn run shadow-cljs compile :extension",
     "watch": "yarn run shadow-cljs watch :extension",
     "release": "yarn run clean && yarn run shadow-cljs release :extension",
-    "package": "yarn run release && vsce package"
+    "package": "yarn run release && vsce package",
+    "package_debug": "yarn run clean && yarn run shadow-cljs compile :extension && vsce package"
   },
   "devDependencies": {
     "@types/vscode": "^1.51.0",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
-{:dependencies [[zprint "1.2.2"]]
+{:dependencies [[zprint "1.2.5"]]
 
  :source-paths ["src"]
 

--- a/src/vscode_clj_zprint/core.cljs
+++ b/src/vscode_clj_zprint/core.cljs
@@ -357,7 +357,7 @@
      ; Do this if we have a vscode config change or if someone forces us to do it anyway
      (when (or new-map vscode-errors force-update?)
        ; Remove current configuration
-       (zprint.config/config-configure-all!)
+       (zprint.config/protected-configure-all!)
        (when @configured? (output-message "Removed existing zprint configuration."))
        (let [external-errors (if ignore-external-files?
                                (output-message


### PR DESCRIPTION
Uses `zprint.config/protected-configure-all!` rather than
`zprint.config/config-configure-all!` which was throwing an error due to a lock
not being acquired.

Also adds `package_debug` task for easier debugging releases.

fixes #6